### PR TITLE
Add close method to TTS class

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -134,6 +134,9 @@ class TTS(tts.TTS):
     ) -> tts.SynthesizeStream:
         return SynthesizeStream(self._session, self._config)
 
+    async def close(self):
+        await self._session.close()
+
 
 class SynthesizeStream(tts.SynthesizeStream):
     def __init__(


### PR DESCRIPTION
I add this close method to the TTS class to close the aiohttp client:

```
    async def close(self):
        await self._session.close()
```

Merge this first, then delete and reinstall your livekit agent plugin install in your virtual environment to be able to test with this change with this PR in backend-core:

https://github.com/luna-ai-tutor/backend-core/pull/141